### PR TITLE
Make AirtableError extend Error

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -19,11 +19,29 @@ module.exports = AbortController;
 
 },{"abort-controller":20,"abortcontroller-polyfill/dist/cjs-ponyfill":19}],2:[function(require,module,exports){
 "use strict";
-var AirtableError = /** @class */ (function () {
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var AirtableError = /** @class */ (function (_super) {
+    __extends(AirtableError, _super);
     function AirtableError(error, message, statusCode) {
-        this.error = error;
-        this.message = message;
-        this.statusCode = statusCode;
+        var _this = _super.call(this, message) || this;
+        _this.name = 'AirtableError';
+        _this.error = error;
+        _this.message = message;
+        _this.statusCode = statusCode;
+        _this.toString = AirtableError.prototype.toString.bind(_this);
+        return _this;
     }
     AirtableError.prototype.toString = function () {
         return [
@@ -35,7 +53,7 @@ var AirtableError = /** @class */ (function () {
         ].join('');
     };
     return AirtableError;
-}());
+}(Error));
 module.exports = AirtableError;
 
 },{}],3:[function(require,module,exports){

--- a/src/airtable_error.ts
+++ b/src/airtable_error.ts
@@ -1,12 +1,15 @@
-class AirtableError {
+class AirtableError extends Error {
     error: string;
     message: string;
     statusCode: number;
 
     constructor(error: string, message: string, statusCode: number) {
+        super(message);
+        this.name = 'AirtableError';
         this.error = error;
         this.message = message;
         this.statusCode = statusCode;
+        this.toString = AirtableError.prototype.toString.bind(this);
     }
 
     toString(): string {

--- a/test/airtable_error.test.js
+++ b/test/airtable_error.test.js
@@ -19,4 +19,14 @@ describe('AirtableError', function() {
             expect(error.toString()).toEqual(expect.stringContaining('404'));
         });
     });
+
+    it('has a stacktrace', function() {
+        var error = new AirtableError('TEST_ERROR', 'A test error', 400);
+        expect(error.stack).toEqual(expect.stringContaining('airtable_error.test.js'));
+    });
+
+    it('has a name', function() {
+        var error = new AirtableError('TEST_ERROR', 'A test error', 400);
+        expect(error.name).toEqual('AirtableError');
+    });
 });

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -271,7 +271,7 @@ describe('Base', function() {
                     res.status(401).json({});
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'AUTHENTICATION_REQUIRED',
                     message: expect.any(String),
                     statusCode: 401,
@@ -285,7 +285,7 @@ describe('Base', function() {
                         .end();
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'NOT_AUTHORIZED',
                     message: expect.any(String),
                     statusCode: 403,
@@ -299,7 +299,7 @@ describe('Base', function() {
                         .end();
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'NOT_FOUND',
                     message: expect.any(String),
                     statusCode: 404,
@@ -315,7 +315,7 @@ describe('Base', function() {
                     });
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'NOT_FOUND',
                     message: 'foo bar',
                     statusCode: 404,
@@ -329,7 +329,7 @@ describe('Base', function() {
                         .end();
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'REQUEST_TOO_LARGE',
                     message: expect.any(String),
                     statusCode: 413,
@@ -343,7 +343,7 @@ describe('Base', function() {
                         .end();
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'UNPROCESSABLE_ENTITY',
                     message: expect.any(String),
                     statusCode: 422,
@@ -359,7 +359,7 @@ describe('Base', function() {
                     });
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'FOO_BAR',
                     message: expect.any(String),
                     statusCode: 422,
@@ -375,7 +375,7 @@ describe('Base', function() {
                     });
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'UNPROCESSABLE_ENTITY',
                     message: 'foo bar',
                     statusCode: 422,
@@ -395,7 +395,7 @@ describe('Base', function() {
                     noRetryIfRateLimited: true,
                 }).base('app123');
 
-                return expect(base.makeRequest()).rejects.toEqual({
+                return expect(base.makeRequest()).rejects.toMatchObject({
                     error: 'TOO_MANY_REQUESTS',
                     message: expect.any(String),
                     statusCode: 429,
@@ -425,7 +425,7 @@ describe('Base', function() {
                         .end();
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'SERVER_ERROR',
                     message: expect.any(String),
                     statusCode: 500,
@@ -439,7 +439,7 @@ describe('Base', function() {
                         .end();
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'SERVICE_UNAVAILABLE',
                     message: expect.any(String),
                     statusCode: 503,
@@ -453,7 +453,7 @@ describe('Base', function() {
                         .end();
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'UNEXPECTED_ERROR',
                     message: expect.any(String),
                     statusCode: 402,
@@ -467,7 +467,7 @@ describe('Base', function() {
                     });
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'FOO_BAR',
                     message: expect.any(String),
                     statusCode: 402,
@@ -481,7 +481,7 @@ describe('Base', function() {
                     });
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'UNEXPECTED_ERROR',
                     message: 'foo bar',
                     statusCode: 402,
@@ -494,7 +494,7 @@ describe('Base', function() {
                     res.send('{"foo":');
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'UNEXPECTED_ERROR',
                     message: expect.any(String),
                     statusCode: 200,
@@ -506,7 +506,7 @@ describe('Base', function() {
                     res.json(['foo', 'bar']);
                 });
 
-                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                     error: 'UNEXPECTED_ERROR',
                     message: expect.any(String),
                     statusCode: 200,
@@ -524,7 +524,7 @@ describe('Base', function() {
                         testExpressApp = env.testExpressApp;
                     })
                     .then(function() {
-                        return expect(fakeBase.makeRequest()).rejects.toEqual({
+                        return expect(fakeBase.makeRequest()).rejects.toMatchObject({
                             error: 'CONNECTION_ERROR',
                             message: expect.any(String),
                             statusCode: null,

--- a/test/test_files/airtable.browser.js
+++ b/test/test_files/airtable.browser.js
@@ -19,11 +19,29 @@ module.exports = AbortController;
 
 },{"abort-controller":20,"abortcontroller-polyfill/dist/cjs-ponyfill":19}],2:[function(require,module,exports){
 "use strict";
-var AirtableError = /** @class */ (function () {
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var AirtableError = /** @class */ (function (_super) {
+    __extends(AirtableError, _super);
     function AirtableError(error, message, statusCode) {
-        this.error = error;
-        this.message = message;
-        this.statusCode = statusCode;
+        var _this = _super.call(this, message) || this;
+        _this.name = 'AirtableError';
+        _this.error = error;
+        _this.message = message;
+        _this.statusCode = statusCode;
+        _this.toString = AirtableError.prototype.toString.bind(_this);
+        return _this;
     }
     AirtableError.prototype.toString = function () {
         return [
@@ -35,7 +53,7 @@ var AirtableError = /** @class */ (function () {
         ].join('');
     };
     return AirtableError;
-}());
+}(Error));
 module.exports = AirtableError;
 
 },{}],3:[function(require,module,exports){


### PR DESCRIPTION
This improves error handling by providing users with stacktraces, as well as improves compatibility with common error handling libraries that test for `instanceof Error`.